### PR TITLE
update example to use latest pntr_color shape

### DIFF
--- a/cmake/Findpntr.cmake
+++ b/cmake/Findpntr.cmake
@@ -3,6 +3,6 @@ include(FetchContent)
 FetchContent_Declare(
     pntr
     GIT_REPOSITORY https://github.com/robloach/pntr.git
-    GIT_TAG 4e373dde963cd1a4e741dc1df6619ceadf94b9a6
+    GIT_TAG 0516337
 )
 FetchContent_MakeAvailable(pntr)

--- a/test/pntr_brush_test.c
+++ b/test/pntr_brush_test.c
@@ -20,15 +20,15 @@ int main() {
     // Variables
     brush->fillStyle = PNTR_RED;
     pntr_brush_fill_style(brush, PNTR_BLUE);
-    assert(brush->fillStyle.data == PNTR_BLUE.data);
+    assert(brush->fillStyle.value == PNTR_BLUE.value);
 
     brush->strokeStyle = PNTR_PURPLE;
     pntr_brush_stroke_style(brush, PNTR_BLUE);
-    assert(brush->strokeStyle.data == PNTR_BLUE.data);
+    assert(brush->strokeStyle.value == PNTR_BLUE.value);
 
     brush->lineWidth = 4;
     pntr_brush_stroke_style(brush, PNTR_BLUE);
-    assert(brush->strokeStyle.data == PNTR_BLUE.data);
+    assert(brush->strokeStyle.value == PNTR_BLUE.value);
 
     pntr_brush_reset(brush);
 
@@ -64,7 +64,7 @@ int main() {
         pntr_brush_save(brush);
         pntr_brush_stroke_style(brush, PNTR_BLUE);
         pntr_brush_restore(brush);
-        assert(brush->strokeStyle.data == (PNTR_RED).data);
+        assert(brush->strokeStyle.value == (PNTR_RED).value);
     }
 
     // pntr_brush_draw_fill_text()


### PR DESCRIPTION
I think this is the only change needed to get this repo up-to-date with current pntr master.
![pntr_brush_test](https://github.com/user-attachments/assets/29442dc5-0b13-4344-8924-5d2b5f6391ae)
